### PR TITLE
Fix load failure on some systems

### DIFF
--- a/lib/rx.rb
+++ b/lib/rx.rb
@@ -9,7 +9,7 @@ $:.unshift File.dirname(__FILE__) # For use/testing when no gem is installed
 # Returns nothing.
 def require_all(path)
   glob = File.join(File.dirname(__FILE__), path, '*.rb')
-  Dir[glob].each do |f|
+  Dir[glob].sort.each do |f|
     require f
   end
 end


### PR DESCRIPTION
tldr: I've got an exception trying to run tests with rake:

```
/home/brainopia/code/ruby/rx.rb/lib/rx/core/auto_detach_observer.rb:13:in
 `<module:RX>': uninitialized constant RX::ObserverBase (NameError)
```

Long explanation:

Currently `Rx.rb` defines order in which to load subdirectores. Files inside these subdirectories are loaded in order in which they are returned from `Dir.glob`. That ordering is file-system dependent (because of `readdir(3)`).

On my system first file loaded from rx/core is `observer.rb`, which loads in turn `notification.rb`, which loads `observable.rb`, which loads `auto_detach_observer.rb`.

`auto_detach_observer.rb` depends on `observer.rb` to define `RX::ObserverBase` and therefore has `require 'observer'`. But since `observer.rb` loading has already started — require will simply return false. And since `observer.rb` loading has not finished (it started a chain reaction of requires which should finish first) `RX::ObserverBase` is not defined.

Currently ensuring that files are loaded in alphabetic order is enough to fix the load failure. I've done it in this pull-request. Still I'd like to revisit this approach in future since dependence on file names feels sluggish.
