### PR TITLE
Remove capacity planning for priority queue

### DIFF
--- a/lib/rx/concurrency/current_thread_scheduler.rb
+++ b/lib/rx/concurrency/current_thread_scheduler.rb
@@ -31,7 +31,7 @@ module RX
       local_queue = self.class.queue
 
       unless local_queue
-        local_queue = PriorityQueue.new 4
+        local_queue = PriorityQueue.new
         local_queue.push si
 
         self.class.queue = local_queue

--- a/lib/rx/concurrency/historical_scheduler.rb
+++ b/lib/rx/concurrency/historical_scheduler.rb
@@ -9,7 +9,7 @@ module RX
   class HistoricalScheduler < VirtualTimeScheduler
 
     def initialize(clock = Time.new(1, 1, 1))
-      @queue = PriorityQueue.new 1024
+      @queue = PriorityQueue.new
       super(clock)
     end
 

--- a/lib/rx/concurrency/virtual_time_scheduler.rb
+++ b/lib/rx/concurrency/virtual_time_scheduler.rb
@@ -15,7 +15,7 @@ module RX
 
     def initialize(initial_clock)
       @clock = initial_clock
-      @queue = PriorityQueue.new 1024
+      @queue = PriorityQueue.new
       @enabled = false
     end
 

--- a/lib/rx/internal/priority_queue.rb
+++ b/lib/rx/internal/priority_queue.rb
@@ -8,9 +8,9 @@ module RX
 
     attr_reader :length
 
-    def initialize(capacity = 1024)
+    def initialize
       @length = 0
-      @items = Array.new(capacity)
+      @items = []
     end
 
     def peek
@@ -19,7 +19,7 @@ module RX
     end
 
     def shift
-      result = self.peek
+      result = peek
       delete_at 0
       result
     end

--- a/test/rx/internal/test_priority_queue.rb
+++ b/test/rx/internal/test_priority_queue.rb
@@ -24,12 +24,6 @@ class TestPriorityQueue < MiniTest::Unit::TestCase
     assert_equal 500, queue.shift
   end
 
-  def test_dynamic_growth
-    queue = RX::PriorityQueue.new 2
-    10.times { queue.push 400 }
-    assert_equal 10, queue.length
-  end
-
   def test_delete
     queue = RX::PriorityQueue.new
     [1, 4, 5, 2, 3].each {|it| queue.push it }
@@ -41,4 +35,5 @@ class TestPriorityQueue < MiniTest::Unit::TestCase
     assert_equal 4, queue.shift
     assert_equal 5, queue.shift
   end
+
 end


### PR DESCRIPTION
https://gist.github.com/brainopia/221b252ab4864327fb27 — I've tried to demonstrate that using dynamically growing array in priority queue has no noticeable overhead.

MRI has several optimizations regarding array capacity. It will by default embed up to 3 elements into array object memory layout (in next MRI version it may increase) afterwards it will use a separate heap storage allocating each time two times more space when reaching a limit.

It sounds non-optimal to fallback to default behavior if we can preallocate the space we need in one action, but overhead of pushing and percolating a new element to priority queue is much bigger.

Having choice between two equally performing options the simpler one is preferable.
