### PR TITLE
Fix typo in RefCountSubscription

### DIFF
--- a/lib/rx/subscriptions/ref_count_subscription.rb
+++ b/lib/rx/subscriptions/ref_count_subscription.rb
@@ -57,7 +57,7 @@ module RX
       subscription = nil
       @gate.synchronize do
         if @subscription
-          count =- 1
+          @count =- 1
 
           if @primary_unsubscribed && @count == 0
             subscription = @subscription


### PR DESCRIPTION
Missing '@' caused release to reference the local variable `count` instead of the reference count tracked by the variable `@count`
