### PR TITLE
Workaround for the test_parallel_wait test

### DIFF
--- a/test/rx/concurrency/test_async_lock.rb
+++ b/test/rx/concurrency/test_async_lock.rb
@@ -25,6 +25,7 @@ class TestAsyncLock < Minitest::Test
         called1 = true
         # 5
       end
+      Thread.pass  # switch force
       # 8
       assert called1
       assert called2


### PR DESCRIPTION
This test sometimes failed because of the thread switching.
