### PR TITLE
Fix travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
   - 2.1.2
   - 2.2.0
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2.1.1
+  - rbx-2.6
 before_install:
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.2.0
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2.1.1
+before_install:
+  - gem update bundler


### PR DESCRIPTION
This PR fixes travis-ci failures.
 
Travis builds have failed because...
* bundler is too old on travis-ci  
[bundler/bundler#3558](https://github.com/bundler/bundler/issues/3558)  
[travis-ci/travis-ci#3531](https://github.com/travis-ci/travis-ci/issues/3531)

* Rubinius 2.1.1 might unavailable on the travis-ci. Switch to latest version; 2.6. 