### PR TITLE
version 0.0.3

### DIFF
--- a/lib/rx/version.rb
+++ b/lib/rx/version.rb
@@ -1,3 +1,3 @@
 module Rx
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
* As we announced on #85, module name and gem name changed  
  RxRuby to Rx  
  rx_ruby to rx