### PR TITLE
fix "warning: method redefined;"

### DIFF
--- a/test/rx/concurrency/test_scheduled_item.rb
+++ b/test/rx/concurrency/test_scheduled_item.rb
@@ -40,7 +40,7 @@ class TestScheduledItem < Minitest::Test
     assert_raises(RuntimeError) { @item.invoke }
   end
 
-  def test_cancel
+  def test_cancel_and_invoke
     assert_equal(false, @item.cancelled?)
     @item.cancel
     assert_equal(true, @item.cancelled?)

--- a/test/rx/core/test_observer.rb
+++ b/test/rx/core/test_observer.rb
@@ -278,7 +278,7 @@ class TestObserver < Minitest::Test
     refute error
   end
 
-  def test_configure_on_next_on_error_on_completed1
+  def test_configure_on_next_on_error_on_completed2
     ex = RuntimeError.new
     next_called = false
     error = false
@@ -308,7 +308,7 @@ class TestObserver < Minitest::Test
     refute error
   end
 
-  def test_configure_on_next_on_error_on_completed2
+  def test_configure_on_next_on_error_on_completed3
     ex = RuntimeError.new
     next_called = false
     error = false


### PR DESCRIPTION
rename methods defined twice
