### PR TITLE
remove unused variable warning

### DIFF
--- a/test/rx/concurrency/test_default_scheduler.rb
+++ b/test/rx/concurrency/test_default_scheduler.rb
@@ -14,7 +14,7 @@ class TestDefaultScheduler < Minitest::Test
   def test_schedule_with_state
     state = []
     task  = ->(_, s) { s << 1 }
-    d = @scheduler.schedule_with_state(state, task)
+    @scheduler.schedule_with_state(state, task)
     sleep 0.001
 
     assert_equal([1], state)
@@ -23,7 +23,7 @@ class TestDefaultScheduler < Minitest::Test
   def test_schedule_relative_with_state
     state = []
     task  = ->(_, s) { s << 1 }
-    d = @scheduler.schedule_relative_with_state(state, 0.05, task)
+    @scheduler.schedule_relative_with_state(state, 0.05, task)
     sleep 0.1
 
     assert_equal([1], state)

--- a/test/rx/concurrency/test_scheduler.rb
+++ b/test/rx/concurrency/test_scheduler.rb
@@ -99,7 +99,6 @@ class TestBaseScheduler < Minitest::Test
   end
 
   def test_schedule_recursive_relative_non_recursive
-    now  = Time.now
     ran  = false
     task = ->(a) { ran = true }
 
@@ -111,7 +110,6 @@ class TestBaseScheduler < Minitest::Test
   end
 
   def test_schedule_recursive_relative_recursive
-    now   = Time.now
     calls = 0
     task  = ->(a) do
       calls += 1


### PR DESCRIPTION
```
/Users/takkanm/src/github.com/ReactiveX/RxRuby/test/rx/concurrency/test_default_scheduler.rb:17:
warning: assigned but unused variable - d
/Users/takkanm/src/github.com/ReactiveX/RxRuby/test/rx/concurrency/test_default_scheduler.rb:26:
warning: assigned but unused variable - d
/Users/takkanm/src/github.com/ReactiveX/RxRuby/test/rx/concurrency/test_scheduler.rb:102:
warning: assigned but unused variable - now
/Users/takkanm/src/github.com/ReactiveX/RxRuby/test/rx/concurrency/test_scheduler.rb:114:
warning: assigned but unused variable - now
```