### PR TITLE
Error message when passing e.g. lambda to Observable#subscribe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ rvm:
   - 2.3.0
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2.6
+  - rbx-3.82
 before_install:
-  - gem update bundler
+  - ruby --version | grep -qF 'rubinius 2.6' || gem update bundler

--- a/examples/if.rb
+++ b/examples/if.rb
@@ -4,9 +4,11 @@ require 'rx'
 should_run = true
 
 source = Rx::Observable.if(
-    lambda { return should_run },
+    lambda { puts 'Condition'; return should_run },
     Rx::Observable.return(42)
 )
+
+puts 'Before'
 
 subscription = source.subscribe(
     lambda {|x|
@@ -19,6 +21,8 @@ subscription = source.subscribe(
         puts 'Completed'
     })
 
+# => Before
+# => Condition
 # => Next: 42
 # => Completed
 
@@ -26,10 +30,12 @@ subscription = source.subscribe(
 should_run = false
 
 source = Rx::Observable.if(
-    lambda { return should_run },
+    lambda { puts 'Condition'; return should_run },
     Rx::Observable.return(42),
     Rx::Observable.return(56)
 )
+
+puts 'Before'
 
 subscription = source.subscribe(
     lambda {|x|
@@ -42,5 +48,7 @@ subscription = source.subscribe(
         puts 'Completed'
     })
 
+# => Before
+# => Condition
 # => Next: 56
 # => Completed

--- a/lib/rx/core/observable.rb
+++ b/lib/rx/core/observable.rb
@@ -19,6 +19,7 @@ module Rx
           _subscribe Observer.configure
         end
       when 1
+        raise ArgumentError.new 'Must pass observer as single argument' unless args[0].is_a? ObserverBase
         _subscribe args[0]
       when 3
         _subscribe Observer.configure {|o|

--- a/lib/rx/linq/observable/if.rb
+++ b/lib/rx/linq/observable/if.rb
@@ -1,17 +1,18 @@
 module Rx
   class << Observable
     def if(condition, then_source, else_source_or_scheduler = nil)
-      case else_source_or_scheduler
-      when Scheduler
-        scheduler = else_source_or_scheduler
-        else_source = Observable.empty(scheduler)
-      when Observable
-        else_source = else_source_or_scheduler
-      when nil
-        else_source = Observable.empty
-      end
+      defer do
+        if else_source_or_scheduler.respond_to?(:subscribe)
+          else_source = else_source_or_scheduler
+        elsif else_source_or_scheduler.nil?
+          else_source = Observable.empty
+        else
+          scheduler = else_source_or_scheduler
+          else_source = Observable.empty(scheduler)
+        end
 
-      return condition.call ? then_source : else_source
+        condition.call ? then_source : else_source
+      end
     end
   end
 end

--- a/lib/rx/subjects/behavior_subject.rb
+++ b/lib/rx/subjects/behavior_subject.rb
@@ -31,8 +31,8 @@ module Rx
 
     # Gets the current value or throws an exception.
     def value
-      gate.synchronize do 
-        self.check_unsubscribed
+      gate.synchronize do
+        check_unsubscribed
         raise @error if @error
         @value
       end
@@ -41,8 +41,8 @@ module Rx
     # Notifies all subscribed observers about the end of the sequence.
     def on_completed
       os = nil
-      @gate.synchronize do 
-        self.check_unsubscribed
+      @gate.synchronize do
+        check_unsubscribed
 
         unless @stopped
           os = @observers.clone
@@ -60,7 +60,7 @@ module Rx
 
       os = nil
       @gate.synchronize do
-        self.check_unsubscribed
+        check_unsubscribed
 
         unless @stopped
           os = @observers.clone
@@ -77,7 +77,7 @@ module Rx
     def on_next(value) 
       os = nil
       @gate.synchronize do
-        self.check_unsubscribed
+        check_unsubscribed
         @value = value
         os = @observers.clone unless @stopped
       end
@@ -91,7 +91,7 @@ module Rx
 
       err = nil
       gate.synchronize do
-        self.check_unsubscribed
+        check_unsubscribed
 
         unless @stopped
           observers.push(observer)

--- a/lib/rx/testing/mock_observer.rb
+++ b/lib/rx/testing/mock_observer.rb
@@ -6,9 +6,7 @@ require 'rx/testing/recorded'
 
 module Rx
 
-  class MockObserver
-    include Observer
-
+  class MockObserver < ObserverBase
     attr_reader :messages
 
     def initialize(scheduler)

--- a/test/rx/concurrency/test_periodic_scheduler.rb
+++ b/test/rx/concurrency/test_periodic_scheduler.rb
@@ -1,21 +1,15 @@
 # Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 require 'test_helper'
+require 'rx/subscriptions/helpers/await_helpers'
 
 class PeriodicTestClass
   include Rx::PeriodicScheduler
 end
 
-def await_array_length(array, expected, interval)
-  sleep (expected * interval) * 0.9
-  deadline = Time.now + interval * (expected + 1)
-  while Time.now < deadline
-    break if array.length == expected
-    sleep interval / 10
-  end
-end
-
 class TestPeriodicScheduler < Minitest::Test
+  include AwaitHelpers
+
   def setup
     @scheduler = PeriodicTestClass.new
   end

--- a/test/rx/linq/observable/test_if.rb
+++ b/test/rx/linq/observable/test_if.rb
@@ -1,0 +1,54 @@
+require "#{File.dirname(__FILE__)}/../../../test_helper"
+
+class TestObservableCreation < Minitest::Test
+  include Rx::ReactiveTest
+
+  def test_if
+    scheduler = Rx::TestScheduler.new
+
+    called = false
+    res = scheduler.configure do
+      xs = Rx::Observable.if(
+        lambda { called = true; true },
+        scheduler.create_cold_observable(
+          on_next(100, scheduler.clock),
+          on_completed(200)
+        )
+      )
+      refute called
+      xs
+    end
+
+    msgs = [on_next(300, 100), on_completed(400)]
+    assert_messages msgs, res.messages
+  end
+
+  def test_if_else
+    scheduler = Rx::TestScheduler.new
+
+    res = scheduler.configure do
+      Rx::Observable.if(
+        lambda { false },
+        scheduler.create_cold_observable(on_completed(100)),
+        scheduler.create_cold_observable(on_completed(101))
+      )
+    end
+
+    msgs = [on_completed(301)]
+    assert_messages msgs, res.messages
+  end
+
+  def test_if_not
+    scheduler = Rx::TestScheduler.new
+
+    res = scheduler.configure do
+      Rx::Observable.if(
+        lambda { false },
+        scheduler.create_cold_observable(on_completed(200))
+      )
+    end
+
+    msgs = [on_completed(200)]
+    assert_messages msgs, res.messages
+  end
+end

--- a/test/rx/subjects/test_behavior_subject.rb
+++ b/test/rx/subjects/test_behavior_subject.rb
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+require 'test_helper'
+
+class TestBehaviorSubject < Minitest::Test
+  def test_subscriber_notified_on_change
+    value = 0
+    subject = Rx::BehaviorSubject.new 0
+    subject.as_observable.subscribe { |update| value = update }
+    subject.on_next 1
+    assert_equal 1, value
+  end
+
+  def test_multiple_observers_notified_on_change
+    value1 = 0
+    value2 = 0
+    subject = Rx::BehaviorSubject.new 0
+    subject.as_observable.subscribe { |update| value1 = update }
+    subject.as_observable.subscribe { |update| value2 = update }
+    subject.on_next 1
+    assert_equal 1, value1
+    assert_equal 1, value2
+  end
+
+  def test_errors_on_next_when_unsubscribed
+    subject = Rx::BehaviorSubject.new 0
+    subject.as_observable.subscribe { }
+    subject.unsubscribe
+    assert_raises(RuntimeError) { subject.on_next 1 }
+  end
+end

--- a/test/rx/subscriptions/helpers/await_helpers.rb
+++ b/test/rx/subscriptions/helpers/await_helpers.rb
@@ -1,0 +1,10 @@
+module AwaitHelpers
+  def await_array_length(array, expected, interval)
+    sleep (expected * interval) * 0.9
+    deadline = Time.now + interval * (expected + 1)
+    while Time.now < deadline
+      break if array.length == expected
+      sleep interval / 10
+    end
+  end
+end


### PR DESCRIPTION
It is easy to make this mistake:
```ruby
p = lambda { |x| puts x }
Rx::Observable.of(1,2,3).skip_last(1).subscribe(p) # <- should be an obsever!
```
which produces a rather confusing error message:
```
rxruby/lib/rx/core/auto_detach_observer.rb:13:in `on_next_core': undefined method `on_next' for #<Proc:0x007fcf48938608@./test.rb:4 (lambda)> (NoMethodError)
	from rxruby/lib/rx/core/observer.rb:90:in `call'
	from rxruby/lib/rx/core/observer.rb:90:in `on_next'
	from rxruby/lib/rx/operators/single.rb:261:in `block (3 levels) in skip_last'
	from rxruby/lib/rx/core/observer.rb:90:in `call'
	from rxruby/lib/rx/core/observer.rb:90:in `on_next'
```
This PR gives this error a better description and also fails immediately rather than on first emitted item:
```
rxruby/lib/rx/core/observable.rb:22:in `subscribe': Must pass observer as single argument (ArgumentError)
	from ./test.rb:5:in `<main>'
```
In case Google randomly landed you here, this is what correct usage look like:
```ruby
p = lambda { |x| puts x }
x = Rx::Observer.configure { |o| o.on_next(&p) }
Rx::Observable.of(1,2,3).skip_last(1).subscribe(x)
```