### PR TITLE
Add default combining behavior to combine_latest operator

### DIFF
--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -116,6 +116,8 @@ module Rx
     # Merges two observable sequences into one observable sequence by using the selector function whenever one of the observable sequences produces an element.
     def combine_latest(other, &result_selector)
       AnonymousObservable.new do |observer|
+        result_selector ||= lambda {|*inner_args| inner_args }
+
         has_left = false
         has_right = false
 


### PR DESCRIPTION
When no block is specified, the `combine_latest` operator should combine its two streams into an array (a pair of elements).

Currently, `combine_latest` errors when no block is specified:

```ruby
require 'rx'
require 'pp'

left = Rx::Subject.new
right = Rx::Subject.new

lo = left.as_observable
ro = right.as_observable

lo.combine_latest(ro).subscribe { |x| pp x }

left.on_next(1);
right.on_next(1);
left.on_next(2);
right.on_next(2);

# Error output (truncated):
# rx-0.0.3/lib/rx/operators/multiple.rb:168:in `block (3 levels) in combine_latest': undefined method `call' for nil:NilClass (NoMethodError)
```

In the RxJS implementation, elements from both streams are combined into an array by default:

```js
let left = new Rx.Subject();
let right = new Rx.Subject();

let lo = left.asObservable();
let ro = right.asObservable();

lo.combineLatest(ro).subscribe(x => console.log(x));

left.onNext(1);
right.onNext(1);
left.onNext(2);
right.onNext(2);

/*
As expected, this prints:
[1, 1]
[2, 1]
[2, 2]
*/
```

In RxRuby, this is also the behavior with the static version of `combine_latest`, i.e. `Rx::Observable.combine_latest(lo, ro).subscribe { |x| pp x }` works as expected ([see implementation here](https://github.com/ReactiveX/RxRuby/blob/master/lib/rx/operators/multiple.rb#L496))

This patch updates the instances version of `combine_latest` to match the static version and make `lo.combine_latest(ro).subscribe { |x| pp x }` work as expected by combining the elements into an array.
