### PR TITLE
Modernize Ubuntu distro to make Rubinius 2.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+dist: trusty
 cache: bundler
 rvm:
   - 1.9.3


### PR DESCRIPTION
This PR opts in to the Travis Ubuntu Trusty container beta so that we may get working Rbx builds for Rubinius 2.6, *making Travis green*. I also tried to build Rubinius versions 3.0 and 3.6 but the ones available via rvm seems to require fairly specific OpenSSL version: https://travis-ci.org/bittrance/rxruby/jobs/193589985
```
ERROR:  Loading command: update (LoadError::InvalidExtensionError)
	Could not open library /home/travis/.rvm/rubies/rbx-3.0/gems/gems/rubysl-openssl-2.8.0/lib/openssl/openssl.so - /home/travis/.rvm/rubies/rbx-3.0/gems/gems/rubysl-openssl-2.8.0/lib/openssl/openssl.so: symbol CRYPTO_memcmp, version OPENSSL_1.0.0 not defined in file libcrypto.so.1.0.0 with link time reference
ERROR:  While executing gem ... (NoMethodError)
    undefined method `invoke_with_build_args' on nil:NilClass.
```
I tried an `apt-get install openssl libssl1.0.0` but that seems not to have helped.