### PR TITLE
Implement the sample operator

### DIFF
--- a/examples/sample.rb
+++ b/examples/sample.rb
@@ -1,0 +1,50 @@
+require 'rx'
+
+# With an interval time
+source = Rx::Observable.interval(0.05)
+    .delay(0.01)
+    .sample(0.15)
+    .take(2)
+
+source.subscribe(
+    lambda { |x|
+        puts 'Next: ' + x.to_s
+    },
+    lambda { |err|
+        puts 'Error: ' + err.inspect
+    },
+    lambda {
+        puts 'Completed'
+    })
+
+# => Next: 1
+# => Next: 4
+# => Completed
+
+while Thread.list.size > 1
+  (Thread.list - [Thread.current]).each(&:join)
+end
+
+# With a sampler
+source = Rx::Observable.interval(0.05)
+    .sample(Rx::Observable.interval(0.15).delay(0.01))
+    .take(2)
+
+source.subscribe(
+    lambda { |x|
+        puts 'Next: ' + x.to_s
+    },
+    lambda { |err|
+        puts 'Error: ' + err.inspect
+    },
+    lambda {
+        puts 'Completed'
+    })
+
+# => Next: 2
+# => Next: 5
+# => Completed
+
+while Thread.list.size > 1
+  (Thread.list - [Thread.current]).each(&:join)
+end

--- a/lib/rx/linq/observable/sample.rb
+++ b/lib/rx/linq/observable/sample.rb
@@ -1,0 +1,37 @@
+module Rx
+  module Observable
+    # Return the latest item from this observable when another observable
+    # emits an item.
+    def sample(intervalOrSampler, scheduler = DefaultScheduler.instance)
+      sampler = if intervalOrSampler.is_a? Numeric
+        Observable.interval(intervalOrSampler, scheduler)
+      else
+        intervalOrSampler
+      end
+
+      AnonymousObservable.new do |observer|
+        latest = nil
+        sample_subscription = sampler.subscribe(
+          lambda { |x|
+            observer.on_next latest unless latest.nil?
+            latest = nil
+          },
+          lambda { |err| observer.on_error err },
+          lambda { observer.on_completed }
+        )
+
+        self_observer = Rx::Observer.configure do |me|
+          me.on_next do |value|
+            latest = value
+          end
+          me.on_error(&observer.method(:on_error))
+          me.on_completed(&observer.method(:on_completed))
+        end
+
+        self_subscription = subscribe self_observer
+
+        CompositeSubscription.new [sample_subscription, self_subscription]
+      end
+    end
+  end
+end

--- a/lib/rx/testing/cold_observable.rb
+++ b/lib/rx/testing/cold_observable.rb
@@ -7,6 +7,7 @@ require 'rx/testing/test_subscription'
 module Rx
 
   class ColdObservable
+    include Observable
 
     attr_reader :messages, :subscriptions
 

--- a/test/rx/linq/observable/test_sample.rb
+++ b/test/rx/linq/observable/test_sample.rb
@@ -1,0 +1,96 @@
+require "#{File.dirname(__FILE__)}/../../../test_helper"
+
+class TestObservableCreation < Minitest::Test
+  include Rx::ReactiveTest
+
+  def test_sampler_completes_first
+    scheduler = Rx::TestScheduler.new
+
+    res = scheduler.configure do
+      scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_next(200, 2),
+        on_next(300, 3),
+        on_next(400, 4),
+        on_completed(600)
+      ).sample(
+        scheduler.create_cold_observable(
+          on_next(50, 1),
+          on_next(150, 1),
+          on_next(350, 1),
+          on_completed(400)
+        )
+      )
+    end
+
+    msgs = [
+      on_next(SUBSCRIBED + 150, 1),
+      on_next(SUBSCRIBED + 350, 3),
+      on_completed(600)
+    ]
+    assert_messages msgs, res.messages
+  end
+
+  def test_source_completes_first
+    scheduler = Rx::TestScheduler.new
+
+    res = scheduler.configure do
+      scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_completed(200)
+      ).sample(
+        scheduler.create_cold_observable(
+          on_next(50, 1),
+          on_next(150, 1),
+          on_completed(400)
+        )
+      )
+    end
+
+    msgs = [
+      on_next(SUBSCRIBED + 150, 1),
+      on_completed(400)
+    ]
+    assert_messages msgs, res.messages
+  end
+
+  def test_source_errors
+    # Verify unsubscribe sampler
+    scheduler = Rx::TestScheduler.new
+
+    sampler = nil
+    res = scheduler.configure do
+      sampler = scheduler.create_cold_observable(
+        on_next(50, 1),
+        on_completed(200)
+      )
+
+      scheduler.create_cold_observable(
+        on_error(100, 'badness')
+      ).sample(sampler)
+    end
+
+    msgs = [on_error(SUBSCRIBED + 100, 'badness')]
+    assert_messages msgs, res.messages
+  end
+
+  def test_sampler_errors
+    # Verify unsubscribe source
+    scheduler = Rx::TestScheduler.new
+
+    sampler = nil
+    res = scheduler.configure do
+      sampler = scheduler.create_cold_observable(
+        on_error(50, 'badness'),
+        on_completed(200)
+      )
+
+      scheduler.create_cold_observable(
+        on_next(100, 1)
+      ).sample(sampler)
+    end
+
+    msgs = [on_error(250, 'badness')]
+    assert_messages msgs, res.messages
+  end
+end

--- a/test/rx/linq/observable/test_sample.rb
+++ b/test/rx/linq/observable/test_sample.rb
@@ -54,6 +54,28 @@ class TestObservableCreation < Minitest::Test
     assert_messages msgs, res.messages
   end
 
+  def test_with_recipe
+    scheduler = Rx::TestScheduler.new
+
+    res = scheduler.configure do
+      scheduler.create_cold_observable(
+        on_next(100, 'left'),
+        on_completed(200)
+      ).sample(
+        scheduler.create_cold_observable(
+          on_next(150, 'right'),
+          on_completed(200)
+        )
+      ) { |left, right| [left, right] }
+    end
+
+    msgs = [
+      on_next(SUBSCRIBED + 150, ['left', 'right']),
+      on_completed(400)
+    ]
+    assert_messages msgs, res.messages
+  end
+
   def test_source_errors
     # Verify unsubscribe sampler
     scheduler = Rx::TestScheduler.new


### PR DESCRIPTION
Implement the ReactiveX sample operator, according to http://reactivex.io/documentation/operators/sample.html as best I understand it. It also includes a slight variation of the RxJS example for sample.

In order to write proper tests, this PR also makes the ColdObservable testing class into a proper observable, just like HotObservable testing class already is.

This version uses synchronization to ensure that clearing the `latest` value does not clobber a simultaneously arriving new value. This has the unfortunate effect that a slow observer may block the source stream, but I can't see how this can be avoided without risking data loss.