### PR TITLE
fix `#window_with_time` typo

### DIFF
--- a/lib/rx/operators/time.rb
+++ b/lib/rx/operators/time.rb
@@ -105,7 +105,7 @@ module Rx
 
           o.on_completed do
             gate.synchronize do
-              q.each {|s| s.on_on_completed}
+              q.each {|s| s.on_completed}
               observer.on_completed
             end
           end


### PR DESCRIPTION
fix typo `on_on_completed` to `on_completed`(reported on https://github.com/ReactiveX/RxRuby/issues/93)