### PR TITLE
Periodic scheduler tests survive GCE

### DIFF
--- a/test/rx/concurrency/test_periodic_scheduler.rb
+++ b/test/rx/concurrency/test_periodic_scheduler.rb
@@ -6,24 +6,35 @@ class PeriodicTestClass
   include Rx::PeriodicScheduler
 end
 
+def await_array_length(array, expected, interval)
+  sleep (expected * interval) * 0.9
+  deadline = Time.now + interval * (expected + 1)
+  while Time.now < deadline
+    break if array.length == expected
+    sleep interval / 10
+  end
+end
+
 class TestPeriodicScheduler < Minitest::Test
   def setup
     @scheduler = PeriodicTestClass.new
   end
 
+  INTERVAL = 0.05
+
   def test_periodic_with_state
     state = []
     task  = ->(x) { x << 1 }
 
-    subscription = @scheduler.schedule_periodic_with_state(state, 0.01, task)
-    sleep 0.025
+    subscription = @scheduler.schedule_periodic_with_state(state, INTERVAL, task)
+    await_array_length(state, 2, INTERVAL)
     subscription.unsubscribe
     assert_equal(state.length, 2)
   end
 
   def test_periodic_with_state_exceptions
     assert_raises(RuntimeError) do
-      @scheduler.schedule_periodic_with_state([], 0.01, nil)
+      @scheduler.schedule_periodic_with_state([], INTERVAL, nil)
     end
 
     assert_raises(RuntimeError) do
@@ -35,15 +46,15 @@ class TestPeriodicScheduler < Minitest::Test
     state = []
     task  = ->() { state << 1 }
 
-    subscription = @scheduler.schedule_periodic(0.01, task)
-    sleep 0.025
+    subscription = @scheduler.schedule_periodic(INTERVAL, task)
+    await_array_length(state, 2, INTERVAL)
     subscription.unsubscribe
     assert_equal(state.length, 2)
   end
 
   def test_periodic_exceptions
     assert_raises(RuntimeError) do
-      @scheduler.schedule_periodic(0.01, nil)
+      @scheduler.schedule_periodic(INTERVAL, nil)
     end
 
     assert_raises(RuntimeError) do


### PR DESCRIPTION
The sleep:ing tests in test/rx/concurrency/test_periodic_scheduler.rb were always sensitive to delays (read noisy neighbours), but on dev machines and traditional Travis, they usually passed. However, on switching to Travis container beta (https://docs.travis-ci.com/user/trusty-ci-environment/) they usually fails at least one Ruby version. This PR makes these tests slower, but also makes them somewhat less sensitive and allows to easily change the "tick" interval.